### PR TITLE
Use the tracker as the x-axis label

### DIFF
--- a/src/app/lorax/directives/chart-data-tracking.js
+++ b/src/app/lorax/directives/chart-data-tracking.js
@@ -76,7 +76,7 @@ define(['jquery'], function ($) {
 
             // transform the raw data into what the below function expects
             for (var i = 0, l = trackers.length; i < l; i++) {
-                var trackerData = trackers[i].company + ' - ' + trackers[i].tracker;
+                var trackerData = trackers[i].tracker + ' - ' + trackers[i].company;
                 graphData.push([trackerData, trackers[i].percent]);
             }
 


### PR DESCRIPTION
Quick update to use the tracker as the x-axis instead of the company name.

Per the conversation in [#72](https://github.com/mozilla/lorax/pull/72#issuecomment-99578053)